### PR TITLE
Redirect to Linktree

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "https://linktr.ee/durjam",
+        permanent: false,
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Temporarily redirecting the domain (https://durjam.co.uk/) to DurJam's Linktree (https://linktr.ee/durjam).